### PR TITLE
fixes #16: catch the parse exception when a column expression is too c…

### DIFF
--- a/spring-cloud-starter-stream-sink-jdbc/src/test/java/org/springframework/cloud/stream/app/jdbc/sink/JdbcSinkIntegrationTests.java
+++ b/spring-cloud-starter-stream-sink-jdbc/src/test/java/org/springframework/cloud/stream/app/jdbc/sink/JdbcSinkIntegrationTests.java
@@ -219,6 +219,20 @@ public abstract class JdbcSinkIntegrationTests {
 		}
 	}
 
+	@TestPropertySource(properties = "jdbc.columns=a: new StringBuilder(payload.a).reverse().toString(), b")
+	public static class UnqualifiableColumnExpressionTests extends JdbcSinkIntegrationTests {
+
+		@Test
+		public void doesNotFailParsingUnqualifiableExpression() {
+
+			// if the app initializes, the test condition passes, but go ahead and apply the column expression anyway
+			channels.input().send(MessageBuilder.withPayload(new Payload("desrever", 123)).build());
+
+			Assert.assertThat(jdbcOperations.queryForObject("select count(*) from messages where a = ? and b = ?",
+				Integer.class, "reversed", 123), is(1));
+		}
+	}
+
 	public static class Payload {
 
 		private String a;


### PR DESCRIPTION
This should retain backward compatibility with unqualified payload expressions and fix my problem (issue #16).  I only put it on my forked 1.2.x branch, but it should be easily applicable to master as well.

Resolves spring-cloud-stream-app-starters/jdbc#16