### PR TITLE
Support for JDBC batch inserts

### DIFF
--- a/spring-cloud-starter-stream-sink-jdbc/README.adoc
+++ b/spring-cloud-starter-stream-sink-jdbc/README.adoc
@@ -54,6 +54,8 @@ So, we can insert it into the table with `name`, `city` and `street` structure u
 --jdbc.columns=name,city:address.city,street:address.street
 ```
 
+This sink supports batch inserts, as far as supported by the underlying JDBC driver. Batch inserts are configured via the `batch-size` and  `idle-timeout` properties: Incoming messages are aggregated until `batch-size` messages are present, then inserted as a batch. If `idle-timeout` milliseconds pass with no new messages, the aggregated batch is inserted even if it is smaller than `batch-size`, capping maximum latency.
+
 NOTE: The module also uses Spring Boot's http://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-sql.html#boot-features-configure-datasource[DataSource support] for configuring the database connection, so properties like `spring.datasource.url` _etc._ apply.
 
 == Build

--- a/spring-cloud-starter-stream-sink-jdbc/README.adoc
+++ b/spring-cloud-starter-stream-sink-jdbc/README.adoc
@@ -54,7 +54,10 @@ So, we can insert it into the table with `name`, `city` and `street` structure u
 --jdbc.columns=name,city:address.city,street:address.street
 ```
 
-This sink supports batch inserts, as far as supported by the underlying JDBC driver. Batch inserts are configured via the `batch-size` and  `idle-timeout` properties: Incoming messages are aggregated until `batch-size` messages are present, then inserted as a batch. If `idle-timeout` milliseconds pass with no new messages, the aggregated batch is inserted even if it is smaller than `batch-size`, capping maximum latency.
+This sink supports batch inserts, as far as supported by the underlying JDBC driver.
+Batch inserts are configured via the `batch-size` and  `idle-timeout` properties:
+Incoming messages are aggregated until `batch-size` messages are present, then inserted as a batch.
+If `idle-timeout` milliseconds pass with no new messages, the aggregated batch is inserted even if it is smaller than `batch-size`, capping maximum latency.
 
 NOTE: The module also uses Spring Boot's http://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-sql.html#boot-features-configure-datasource[DataSource support] for configuring the database connection, so properties like `spring.datasource.url` _etc._ apply.
 

--- a/spring-cloud-starter-stream-sink-jdbc/README.adoc
+++ b/spring-cloud-starter-stream-sink-jdbc/README.adoc
@@ -26,6 +26,8 @@ $$jdbc.columns$$:: $$The comma separated colon-based pairs of column names and S
  Names are used at initialization time to issue the DDL.$$ *($$String$$, default: `$$payload:payload.toString()$$`)*
 $$jdbc.initialize$$:: $$'true', 'false' or the location of a custom initialization script for the table.$$ *($$String$$, default: `$$false$$`)*
 $$jdbc.table-name$$:: $$The name of the table to write into.$$ *($$String$$, default: `$$messages$$`)*
+$$jdbc.batch-size$$:: $$Threshold in number of messages when data will be flushed to database table.$$ *($$Integer$$, default: `$$1$$`)*
+$$jdbc.idle-timeout$$:: $$Idle timeout in milliseconds when data is automatically flushed to database table.$$ *($$Long$$, default: `$$-1$$`)*
 $$spring.datasource.data$$:: $$Data (DML) script resource references.$$ *($$List<String>$$, default: `$$<none>$$`)*
 $$spring.datasource.driver-class-name$$:: $$Fully qualified name of the JDBC driver. Auto-detected based on the URL by default.$$ *($$String$$, default: `$$<none>$$`)*
 $$spring.datasource.initialization-mode$$:: $$Initialize the datasource using available DDL and DML scripts.$$ *($$DataSourceInitializationMode$$, default: `$$embedded$$`, possible values: `ALWAYS`,`EMBEDDED`,`NEVER`)*

--- a/spring-cloud-starter-stream-sink-jdbc/src/main/java/org/springframework/cloud/stream/app/jdbc/sink/JdbcSinkConfiguration.java
+++ b/spring-cloud-starter-stream-sink-jdbc/src/main/java/org/springframework/cloud/stream/app/jdbc/sink/JdbcSinkConfiguration.java
@@ -16,6 +16,12 @@
 
 package org.springframework.cloud.stream.app.jdbc.sink;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.PostConstruct;
+import javax.sql.DataSource;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -61,12 +67,6 @@ import org.springframework.messaging.MessageHandler;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
-import javax.annotation.PostConstruct;
-import javax.sql.DataSource;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 /**
  * A module that writes its incoming payload to an RDBMS using JDBC.
  *
@@ -79,178 +79,178 @@ import java.util.Set;
 @EnableConfigurationProperties(JdbcSinkProperties.class)
 public class JdbcSinkConfiguration {
 
-    private static final Log logger = LogFactory.getLog(JdbcSinkConfiguration.class);
+	private static final Log logger = LogFactory.getLog(JdbcSinkConfiguration.class);
 
-    private static final Object NOT_SET = new Object();
+	private static final Object NOT_SET = new Object();
 
-    private SpelExpressionParser spelExpressionParser = new SpelExpressionParser();
+	private SpelExpressionParser spelExpressionParser = new SpelExpressionParser();
 
-    @Autowired
-    private BeanFactory beanFactory;
+	@Autowired
+	private BeanFactory beanFactory;
 
-    @Autowired
-    private JdbcSinkProperties properties;
+	@Autowired
+	private JdbcSinkProperties properties;
 
-    private EvaluationContext evaluationContext;
+	private EvaluationContext evaluationContext;
 
-    @Bean
-    public MessageChannel toSink() {
-        return new DirectChannel();
-    }
+	@Bean
+	public MessageChannel toSink() {
+		return new DirectChannel();
+	}
 
-    @Bean
-    @Primary
-    @ServiceActivator(autoStartup = "true", inputChannel = Sink.INPUT)
-    FactoryBean<MessageHandler> aggregatorFactoryBean(MessageChannel toSink, MessageGroupStore messageGroupStore) {
-        AggregatorFactoryBean aggregatorFactoryBean = new AggregatorFactoryBean();
-        aggregatorFactoryBean.setCorrelationStrategy(new ExpressionEvaluatingCorrelationStrategy("payload.getClass().name"));
-        aggregatorFactoryBean.setReleaseStrategy(new MessageCountReleaseStrategy(properties.getBatchSize()));
-        aggregatorFactoryBean.setGroupTimeoutExpression(new ValueExpression<>(properties.getIdleTimeout()));
-        aggregatorFactoryBean.setMessageStore(messageGroupStore);
-        aggregatorFactoryBean.setProcessorBean(new DefaultAggregatingMessageGroupProcessor());
-        aggregatorFactoryBean.setExpireGroupsUponCompletion(true);
-        aggregatorFactoryBean.setSendPartialResultOnExpiry(true);
-        aggregatorFactoryBean.setOutputChannel(toSink);
-        return aggregatorFactoryBean;
-    }
+	@Bean
+	@Primary
+	@ServiceActivator(autoStartup = "true", inputChannel = Sink.INPUT)
+	FactoryBean<MessageHandler> aggregatorFactoryBean(MessageChannel toSink, MessageGroupStore messageGroupStore) {
+		AggregatorFactoryBean aggregatorFactoryBean = new AggregatorFactoryBean();
+		aggregatorFactoryBean.setCorrelationStrategy(new ExpressionEvaluatingCorrelationStrategy("payload.getClass().name"));
+		aggregatorFactoryBean.setReleaseStrategy(new MessageCountReleaseStrategy(properties.getBatchSize()));
+		aggregatorFactoryBean.setGroupTimeoutExpression(new ValueExpression<>(properties.getIdleTimeout()));
+		aggregatorFactoryBean.setMessageStore(messageGroupStore);
+		aggregatorFactoryBean.setProcessorBean(new DefaultAggregatingMessageGroupProcessor());
+		aggregatorFactoryBean.setExpireGroupsUponCompletion(true);
+		aggregatorFactoryBean.setSendPartialResultOnExpiry(true);
+		aggregatorFactoryBean.setOutputChannel(toSink);
+		return aggregatorFactoryBean;
+	}
 
-    @Bean
-    @ServiceActivator(autoStartup = "true", inputChannel = "toSink")
-    public JdbcMessageHandler jdbcMessageHandler(DataSource dataSource) {
-        final MultiValueMap<String, Expression> columnExpressionVariations = new LinkedMultiValueMap<>();
-        for (Map.Entry<String, String> entry : properties.getColumnsMap().entrySet()) {
-            String value = entry.getValue();
-            columnExpressionVariations.add(entry.getKey(), spelExpressionParser.parseExpression(value));
-            if (!value.startsWith("payload")) {
-                String qualified = "payload." + value;
-                try {
-                    columnExpressionVariations.add(entry.getKey(), spelExpressionParser.parseExpression(qualified));
-                } catch (SpelParseException e) {
-                    logger.info("failed to parse qualified fallback expression " + qualified +
-                            "; be sure your expression uses the 'payload.' prefix where necessary");
-                }
-            }
-        }
-        JdbcMessageHandler jdbcMessageHandler = new JdbcMessageHandler(dataSource,
-                generateSql(properties.getTableName(), columnExpressionVariations.keySet()));
-        SqlParameterSourceFactory parameterSourceFactory = new ParameterFactory(
-                columnExpressionVariations, evaluationContext);
-        jdbcMessageHandler.setSqlParameterSourceFactory(parameterSourceFactory);
-        return jdbcMessageHandler;
-    }
+	@Bean
+	@ServiceActivator(autoStartup = "true", inputChannel = "toSink")
+	public JdbcMessageHandler jdbcMessageHandler(DataSource dataSource) {
+		final MultiValueMap<String, Expression> columnExpressionVariations = new LinkedMultiValueMap<>();
+		for (Map.Entry<String, String> entry : properties.getColumnsMap().entrySet()) {
+			String value = entry.getValue();
+			columnExpressionVariations.add(entry.getKey(), spelExpressionParser.parseExpression(value));
+			if (!value.startsWith("payload")) {
+				String qualified = "payload." + value;
+				try {
+					columnExpressionVariations.add(entry.getKey(), spelExpressionParser.parseExpression(qualified));
+				} catch (SpelParseException e) {
+					logger.info("failed to parse qualified fallback expression " + qualified +
+							"; be sure your expression uses the 'payload.' prefix where necessary");
+				}
+			}
+		}
+		JdbcMessageHandler jdbcMessageHandler = new JdbcMessageHandler(dataSource,
+				generateSql(properties.getTableName(), columnExpressionVariations.keySet()));
+		SqlParameterSourceFactory parameterSourceFactory = new ParameterFactory(
+				columnExpressionVariations, evaluationContext);
+		jdbcMessageHandler.setSqlParameterSourceFactory(parameterSourceFactory);
+		return jdbcMessageHandler;
+	}
 
-    @ConditionalOnProperty("jdbc.initialize")
-    @Bean
-    public DataSourceInitializer nonBootDataSourceInitializer(DataSource dataSource, ResourceLoader resourceLoader) {
-        DataSourceInitializer dataSourceInitializer = new DataSourceInitializer();
-        dataSourceInitializer.setDataSource(dataSource);
-        ResourceDatabasePopulator databasePopulator = new ResourceDatabasePopulator();
-        databasePopulator.setIgnoreFailedDrops(true);
-        dataSourceInitializer.setDatabasePopulator(databasePopulator);
-        if ("true".equals(properties.getInitialize())) {
-            databasePopulator.addScript(new DefaultInitializationScriptResource(properties.getTableName(),
-                    properties.getColumnsMap().keySet()));
-        } else {
-            databasePopulator.addScript(resourceLoader.getResource(properties.getInitialize()));
-        }
-        return dataSourceInitializer;
-    }
+	@ConditionalOnProperty("jdbc.initialize")
+	@Bean
+	public DataSourceInitializer nonBootDataSourceInitializer(DataSource dataSource, ResourceLoader resourceLoader) {
+		DataSourceInitializer dataSourceInitializer = new DataSourceInitializer();
+		dataSourceInitializer.setDataSource(dataSource);
+		ResourceDatabasePopulator databasePopulator = new ResourceDatabasePopulator();
+		databasePopulator.setIgnoreFailedDrops(true);
+		dataSourceInitializer.setDatabasePopulator(databasePopulator);
+		if ("true".equals(properties.getInitialize())) {
+			databasePopulator.addScript(new DefaultInitializationScriptResource(properties.getTableName(),
+					properties.getColumnsMap().keySet()));
+		} else {
+			databasePopulator.addScript(resourceLoader.getResource(properties.getInitialize()));
+		}
+		return dataSourceInitializer;
+	}
 
-    @Bean
-    MessageGroupStore messageGroupStore() {
-        SimpleMessageStore messageGroupStore = new SimpleMessageStore();
-        messageGroupStore.setTimeoutOnIdle(true);
-        messageGroupStore.setCopyOnGet(false);
-        return messageGroupStore;
-    }
+	@Bean
+	MessageGroupStore messageGroupStore() {
+		SimpleMessageStore messageGroupStore = new SimpleMessageStore();
+		messageGroupStore.setTimeoutOnIdle(true);
+		messageGroupStore.setCopyOnGet(false);
+		return messageGroupStore;
+	}
 
-    @Bean
-    public static ShorthandMapConverter shorthandMapConverter() {
-        return new ShorthandMapConverter();
-    }
+	@Bean
+	public static ShorthandMapConverter shorthandMapConverter() {
+		return new ShorthandMapConverter();
+	}
 
-    @PostConstruct
-    public void afterPropertiesSet() {
-        this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(beanFactory);
-    }
+	@PostConstruct
+	public void afterPropertiesSet() {
+		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(beanFactory);
+	}
 
-    private String generateSql(String tableName, Set<String> columns) {
-        StringBuilder builder = new StringBuilder("INSERT INTO ");
-        StringBuilder questionMarks = new StringBuilder(") VALUES (");
-        builder.append(tableName).append("(");
-        int i = 0;
+	private String generateSql(String tableName, Set<String> columns) {
+		StringBuilder builder = new StringBuilder("INSERT INTO ");
+		StringBuilder questionMarks = new StringBuilder(") VALUES (");
+		builder.append(tableName).append("(");
+		int i = 0;
 
-        for (String column : columns) {
-            if (i++ > 0) {
-                builder.append(", ");
-                questionMarks.append(", ");
-            }
-            builder.append(column);
-            questionMarks.append(':').append(column);
-        }
-        builder.append(questionMarks).append(")");
-        return builder.toString();
-    }
+		for (String column : columns) {
+			if (i++ > 0) {
+				builder.append(", ");
+				questionMarks.append(", ");
+			}
+			builder.append(column);
+			questionMarks.append(':').append(column);
+		}
+		builder.append(questionMarks).append(")");
+		return builder.toString();
+	}
 
-    private static final class ParameterFactory implements SqlParameterSourceFactory {
+	private static final class ParameterFactory implements SqlParameterSourceFactory {
 
-        private final MultiValueMap<String, Expression> columnExpressions;
+		private final MultiValueMap<String, Expression> columnExpressions;
 
-        private final EvaluationContext context;
+		private final EvaluationContext context;
 
-        ParameterFactory(MultiValueMap<String, Expression> columnExpressions, EvaluationContext context) {
-            this.columnExpressions = columnExpressions;
-            this.context = context;
-        }
+		ParameterFactory(MultiValueMap<String, Expression> columnExpressions, EvaluationContext context) {
+			this.columnExpressions = columnExpressions;
+			this.context = context;
+		}
 
-        @Override
-        public SqlParameterSource createParameterSource(Object o) {
-            if (!(o instanceof Message)) {
-                throw new IllegalArgumentException("Unable to handle type " + o.getClass().getName());
-            }
-            Message<?> message = (Message<?>) o;
-            MapSqlParameterSource parameterSource = new MapSqlParameterSource();
-            for (String key : columnExpressions.keySet()) {
-                List<Expression> spels = columnExpressions.get(key);
-                Object value = NOT_SET;
-                EvaluationException lastException = null;
-                for (Expression spel : spels) {
-                    try {
-                        value = spel.getValue(context, message);
-                        break;
-                    } catch (EvaluationException e) {
-                        lastException = e;
-                    }
-                }
-                if (value == NOT_SET) {
-                    if (lastException != null) {
-                        logger.info("Could not find value for column '" + key + "': " + lastException.getMessage());
-                    }
-                    parameterSource.addValue(key, null);
-                } else {
-                    if (value instanceof JsonPropertyAccessor.ToStringFriendlyJsonNode) {
-                        // Need to do some reflection until we have a getter for the Node
-                        DirectFieldAccessor dfa = new DirectFieldAccessor(value);
-                        JsonNode node = (JsonNode) dfa.getPropertyValue("node");
-                        Object valueToUse;
-                        if (node == null || node.isNull()) {
-                            valueToUse = null;
-                        } else if (node.isNumber()) {
-                            valueToUse = node.numberValue();
-                        } else if (node.isBoolean()) {
-                            valueToUse = node.booleanValue();
-                        } else {
-                            valueToUse = node.textValue();
-                        }
-                        parameterSource.addValue(key, valueToUse);
-                    } else {
-                        parameterSource.addValue(key, value);
-                    }
-                }
-            }
-            return parameterSource;
-        }
+		@Override
+		public SqlParameterSource createParameterSource(Object o) {
+			if (!(o instanceof Message)) {
+				throw new IllegalArgumentException("Unable to handle type " + o.getClass().getName());
+			}
+			Message<?> message = (Message<?>) o;
+			MapSqlParameterSource parameterSource = new MapSqlParameterSource();
+			for (String key : columnExpressions.keySet()) {
+				List<Expression> spels = columnExpressions.get(key);
+				Object value = NOT_SET;
+				EvaluationException lastException = null;
+				for (Expression spel : spels) {
+					try {
+						value = spel.getValue(context, message);
+						break;
+					} catch (EvaluationException e) {
+						lastException = e;
+					}
+				}
+				if (value == NOT_SET) {
+					if (lastException != null) {
+						logger.info("Could not find value for column '" + key + "': " + lastException.getMessage());
+					}
+					parameterSource.addValue(key, null);
+				} else {
+					if (value instanceof JsonPropertyAccessor.ToStringFriendlyJsonNode) {
+						// Need to do some reflection until we have a getter for the Node
+						DirectFieldAccessor dfa = new DirectFieldAccessor(value);
+						JsonNode node = (JsonNode) dfa.getPropertyValue("node");
+						Object valueToUse;
+						if (node == null || node.isNull()) {
+							valueToUse = null;
+						} else if (node.isNumber()) {
+							valueToUse = node.numberValue();
+						} else if (node.isBoolean()) {
+							valueToUse = node.booleanValue();
+						} else {
+							valueToUse = node.textValue();
+						}
+						parameterSource.addValue(key, valueToUse);
+					} else {
+						parameterSource.addValue(key, value);
+					}
+				}
+			}
+			return parameterSource;
+		}
 
-    }
+	}
 
 }

--- a/spring-cloud-starter-stream-sink-jdbc/src/main/java/org/springframework/cloud/stream/app/jdbc/sink/JdbcSinkProperties.java
+++ b/spring-cloud-starter-stream-sink-jdbc/src/main/java/org/springframework/cloud/stream/app/jdbc/sink/JdbcSinkProperties.java
@@ -16,12 +16,11 @@
 
 package org.springframework.cloud.stream.app.jdbc.sink;
 
+import java.util.Map;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.stream.app.jdbc.ShorthandMapConverter;
-
-import java.util.Map;
-
 
 /**
  * Holds configuration properties for the Jdbc Sink module.

--- a/spring-cloud-starter-stream-sink-jdbc/src/main/java/org/springframework/cloud/stream/app/jdbc/sink/JdbcSinkProperties.java
+++ b/spring-cloud-starter-stream-sink-jdbc/src/main/java/org/springframework/cloud/stream/app/jdbc/sink/JdbcSinkProperties.java
@@ -51,6 +51,16 @@ public class JdbcSinkProperties {
 	 */
 	private String initialize = "false";
 
+	/**
+	 * Threshold in number of messages when data will be flushed to database table.
+	 */
+	private int batchSize = 1;
+
+	/**
+	 * Idle timeout in milliseconds when data is automatically flushed to database table.
+	 */
+	private long idleTimeout = -1L;
+
 	private Map<String, String> columnsMap;
 
 	public String getTableName() {
@@ -75,6 +85,22 @@ public class JdbcSinkProperties {
 
 	public void setInitialize(String initialize) {
 		this.initialize = initialize;
+	}
+
+	public int getBatchSize() {
+		return this.batchSize;
+	}
+
+	public void setBatchSize(int batchSize) {
+		this.batchSize = batchSize;
+	}
+
+	public long getIdleTimeout() {
+		return this.idleTimeout;
+	}
+
+	public void setIdleTimeout(long idleTimeout) {
+		this.idleTimeout = idleTimeout;
 	}
 
 	Map<String, String> getColumnsMap() {

--- a/spring-cloud-starter-stream-sink-jdbc/src/main/java/org/springframework/cloud/stream/app/jdbc/sink/JdbcSinkProperties.java
+++ b/spring-cloud-starter-stream-sink-jdbc/src/main/java/org/springframework/cloud/stream/app/jdbc/sink/JdbcSinkProperties.java
@@ -16,11 +16,11 @@
 
 package org.springframework.cloud.stream.app.jdbc.sink;
 
-import java.util.Map;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.stream.app.jdbc.ShorthandMapConverter;
+
+import java.util.Map;
 
 
 /**
@@ -28,6 +28,7 @@ import org.springframework.cloud.stream.app.jdbc.ShorthandMapConverter;
  *
  * @author Eric Bottard
  * @author Artem Bilan
+ * @author Oliver Flasch
  */
 @ConfigurationProperties("jdbc")
 public class JdbcSinkProperties {

--- a/spring-cloud-starter-stream-sink-jdbc/src/test/java/org/springframework/cloud/stream/app/jdbc/sink/JdbcSinkIntegrationTests.java
+++ b/spring-cloud-starter-stream-sink-jdbc/src/test/java/org/springframework/cloud/stream/app/jdbc/sink/JdbcSinkIntegrationTests.java
@@ -16,19 +16,10 @@
 
 package org.springframework.cloud.stream.app.jdbc.sink;
 
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.samePropertyValuesAs;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -44,6 +35,12 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.tuple.Tuple;
 import org.springframework.tuple.TupleBuilder;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.*;
+
 /**
  * Integration Tests for JdbcSink. Uses hsqldb as a (real) embedded DB.
  *
@@ -51,6 +48,7 @@ import org.springframework.tuple.TupleBuilder;
  * @author Thomas Risberg
  * @author Artem Bilan
  * @author Robert St. John
+ * @author Oliver Flasch
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(
@@ -93,7 +91,7 @@ public abstract class JdbcSinkIntegrationTests {
 
 	}
 
-  @TestPropertySource(properties = { "jdbc.batchSize=1000", "jdbc.idleTimeout=1000" })
+  @TestPropertySource(properties = { "jdbc.batchSize=1000", "jdbc.idleTimeout=100" })
 	public static class BatchInsertTimeoutTests extends JdbcSinkIntegrationTests {
 
 		@Test
@@ -104,7 +102,7 @@ public abstract class JdbcSinkIntegrationTests {
   			channels.input().send(MessageBuilder.withPayload(sent).build());
       }
       Assert.assertThat(jdbcOperations.queryForObject("select count(*) from messages", Integer.class), is(0));
-      Thread.sleep(2000); // wait 2s
+      Thread.sleep(200); // wait 200ms
       Assert.assertThat(jdbcOperations.queryForObject("select count(*) from messages", Integer.class), is(numberOfInserts));
 		}
 

--- a/spring-cloud-starter-stream-sink-jdbc/src/test/java/org/springframework/cloud/stream/app/jdbc/sink/JdbcSinkIntegrationTests.java
+++ b/spring-cloud-starter-stream-sink-jdbc/src/test/java/org/springframework/cloud/stream/app/jdbc/sink/JdbcSinkIntegrationTests.java
@@ -16,7 +16,10 @@
 
 package org.springframework.cloud.stream.app.jdbc.sink;
 
-import org.hamcrest.Matchers;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,11 +38,9 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.tuple.Tuple;
 import org.springframework.tuple.TupleBuilder;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.samePropertyValuesAs;
 
 /**
  * Integration Tests for JdbcSink. Uses hsqldb as a (real) embedded DB.
@@ -74,36 +75,36 @@ public abstract class JdbcSinkIntegrationTests {
 		}
 
 	}
-	
-  @TestPropertySource(properties = "jdbc.batchSize=1000")
+
+	@TestPropertySource(properties = "jdbc.batchSize=1000")
 	public static class SimpleBatchInsertTests extends JdbcSinkIntegrationTests {
 
 		@Test
 		public void testBatchInsertion() {
-      final int numberOfInserts = 5000;
+			final int numberOfInserts = 5000;
 			Payload sent = new Payload("hello", 42);
-      for (int i = 0; i < numberOfInserts; i++) {
-  			channels.input().send(MessageBuilder.withPayload(sent).build());
-      }
-      int result = jdbcOperations.queryForObject("select count(*) from messages", Integer.class);
+			for (int i = 0; i < numberOfInserts; i++) {
+				channels.input().send(MessageBuilder.withPayload(sent).build());
+			}
+			int result = jdbcOperations.queryForObject("select count(*) from messages", Integer.class);
 			Assert.assertThat(result, is(numberOfInserts));
 		}
 
 	}
 
-  @TestPropertySource(properties = { "jdbc.batchSize=1000", "jdbc.idleTimeout=100" })
+	@TestPropertySource(properties = {"jdbc.batchSize=1000", "jdbc.idleTimeout=100"})
 	public static class BatchInsertTimeoutTests extends JdbcSinkIntegrationTests {
 
 		@Test
 		public void testBatchInsertionTimeout() throws InterruptedException {
-      final int numberOfInserts = 10;
+			final int numberOfInserts = 10;
 			Payload sent = new Payload("hello", 42);
-      for (int i = 0; i < numberOfInserts; i++) {
-  			channels.input().send(MessageBuilder.withPayload(sent).build());
-      }
-      Assert.assertThat(jdbcOperations.queryForObject("select count(*) from messages", Integer.class), is(0));
-      Thread.sleep(200); // wait 200ms
-      Assert.assertThat(jdbcOperations.queryForObject("select count(*) from messages", Integer.class), is(numberOfInserts));
+			for (int i = 0; i < numberOfInserts; i++) {
+				channels.input().send(MessageBuilder.withPayload(sent).build());
+			}
+			Assert.assertThat(jdbcOperations.queryForObject("select count(*) from messages", Integer.class), is(0));
+			Thread.sleep(200); // wait 200ms
+			Assert.assertThat(jdbcOperations.queryForObject("select count(*) from messages", Integer.class), is(numberOfInserts));
 		}
 
 	}
@@ -116,7 +117,7 @@ public abstract class JdbcSinkIntegrationTests {
 			Payload sent = new Payload("hello", 42);
 			channels.input().send(MessageBuilder.withPayload(sent).build());
 			Payload result = jdbcOperations.query("select a, b from messages", new BeanPropertyRowMapper<>(Payload.class)).get(0);
-			Assert.assertThat(result, Matchers.samePropertyValuesAs(sent));
+			Assert.assertThat(result, samePropertyValuesAs(sent));
 		}
 
 	}
@@ -131,7 +132,7 @@ public abstract class JdbcSinkIntegrationTests {
 			channels.input().send(MessageBuilder.withPayload(sent).build());
 			Payload expected = new Payload("hell", 666);
 			Payload result = jdbcOperations.query("select a, b from messages", new BeanPropertyRowMapper<>(Payload.class)).get(0);
-			Assert.assertThat(result, Matchers.samePropertyValuesAs(expected));
+			Assert.assertThat(result, samePropertyValuesAs(expected));
 		}
 
 	}
@@ -161,7 +162,7 @@ public abstract class JdbcSinkIntegrationTests {
 
 	}
 
-	@TestPropertySource(properties = { "jdbc.tableName=no_script", "jdbc.initialize=true", "jdbc.columns=a,b" })
+	@TestPropertySource(properties = {"jdbc.tableName=no_script", "jdbc.initialize=true", "jdbc.columns=a,b"})
 	public static class ImplicitTableCreationTests extends JdbcSinkIntegrationTests {
 
 		@Test
@@ -169,12 +170,12 @@ public abstract class JdbcSinkIntegrationTests {
 			Payload sent = new Payload("hello", 42);
 			channels.input().send(MessageBuilder.withPayload(sent).build());
 			Payload result = jdbcOperations.query("select a, b from no_script", new BeanPropertyRowMapper<>(Payload.class)).get(0);
-			Assert.assertThat(result, Matchers.samePropertyValuesAs(sent));
+			Assert.assertThat(result, samePropertyValuesAs(sent));
 		}
 
 	}
 
-	@TestPropertySource(properties = { "jdbc.tableName=foobar", "jdbc.initialize=classpath:explicit-script.sql", "jdbc.columns=a,b" })
+	@TestPropertySource(properties = {"jdbc.tableName=foobar", "jdbc.initialize=classpath:explicit-script.sql", "jdbc.columns=a,b"})
 	public static class ExplicitTableCreationTests extends JdbcSinkIntegrationTests {
 
 		@Test
@@ -182,7 +183,7 @@ public abstract class JdbcSinkIntegrationTests {
 			Payload sent = new Payload("hello", 42);
 			channels.input().send(MessageBuilder.withPayload(sent).build());
 			Payload result = jdbcOperations.query("select a, b from foobar", new BeanPropertyRowMapper<>(Payload.class)).get(0);
-			Assert.assertThat(result, Matchers.samePropertyValuesAs(sent));
+			Assert.assertThat(result, samePropertyValuesAs(sent));
 		}
 
 	}


### PR DESCRIPTION
We needed support for JDBC batch inserts to enable efficient data ingestion from fast Kafka topics. 

This pull request uses Spring Integration aggregators to collect up to jdbc.batch-size messages before inserting them into the database. The configuration option jdbc.idle-timeout can be used to define a timeout in milliseconds after which the collected messages are flushed to the database, limiting the maximum latency.