### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
-http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/spring-cloud-starter-stream-sink-jdbc/README.adoc
+++ b/spring-cloud-starter-stream-sink-jdbc/README.adoc
@@ -59,7 +59,7 @@ Batch inserts are configured via the `batch-size` and  `idle-timeout` properties
 Incoming messages are aggregated until `batch-size` messages are present, then inserted as a batch.
 If `idle-timeout` milliseconds pass with no new messages, the aggregated batch is inserted even if it is smaller than `batch-size`, capping maximum latency.
 
-NOTE: The module also uses Spring Boot's http://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-sql.html#boot-features-configure-datasource[DataSource support] for configuring the database connection, so properties like `spring.datasource.url` _etc._ apply.
+NOTE: The module also uses Spring Boot's https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-sql.html#boot-features-configure-datasource[DataSource support] for configuring the database connection, so properties like `spring.datasource.url` _etc._ apply.
 
 == Build
 

--- a/spring-cloud-starter-stream-sink-pgcopy/README.adoc
+++ b/spring-cloud-starter-stream-sink-pgcopy/README.adoc
@@ -49,7 +49,7 @@ $$spring.datasource.url$$:: $$JDBC url of the database.$$ *($$String$$, default:
 $$spring.datasource.username$$:: $$Login username of the database.$$ *($$String$$, default: `$$<none>$$`)*
 //end::configuration-properties[]
 
-NOTE: The module also uses Spring Boot's http://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-sql.html#boot-features-configure-datasource[DataSource support] for configuring the database connection, so properties like `spring.datasource.url` _etc._ apply.
+NOTE: The module also uses Spring Boot's https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-sql.html#boot-features-configure-datasource[DataSource support] for configuring the database connection, so properties like `spring.datasource.url` _etc._ apply.
 
 == Build
 

--- a/spring-cloud-starter-stream-source-jdbc/README.adoc
+++ b/spring-cloud-starter-stream-source-jdbc/README.adoc
@@ -2,7 +2,7 @@
 = JDBC Source
 
 This source polls data from an RDBMS.
-This source is fully based on the `DataSourceAutoConfiguration`, so refer to the http://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-sql.html[Spring Boot JDBC Support] for more information.
+This source is fully based on the `DataSourceAutoConfiguration`, so refer to the https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-sql.html[Spring Boot JDBC Support] for more information.
 
 == Input
 
@@ -42,7 +42,7 @@ $$trigger.max-messages$$:: $$Maximum messages per poll, -1 means infinity.$$ *($
 $$trigger.time-unit$$:: $$The TimeUnit to apply to delay values.$$ *($$TimeUnit$$, default: `$$<none>$$`, possible values: `NANOSECONDS`,`MICROSECONDS`,`MILLISECONDS`,`SECONDS`,`MINUTES`,`HOURS`,`DAYS`)*
 //end::configuration-properties[]
 
-Also see the http://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html[Spring Boot Documentation]
+Also see the https://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html[Spring Boot Documentation]
 for addition `DataSource` properties and `TriggerProperties` and `MaxMessagesProperties` for polling options.
 
 == Build


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-sql.html with 3 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-sql.html ([https](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-sql.html) result 200).
* [ ] http://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html ([https](https://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html) result 200).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).