### PR TITLE
The values of the headers cannot be set to columns in JDBC sink

### DIFF
--- a/spring-cloud-starter-stream-sink-jdbc/src/main/java/org/springframework/cloud/stream/app/jdbc/sink/JdbcSinkConfiguration.java
+++ b/spring-cloud-starter-stream-sink-jdbc/src/main/java/org/springframework/cloud/stream/app/jdbc/sink/JdbcSinkConfiguration.java
@@ -80,6 +80,7 @@ import java.util.stream.StreamSupport;
  * @author Oliver Flasch
  * @author Artem Bilan
  * @author Soby Chacko
+ * @author Szabolcs Stremler
  */
 @EnableBinding(Sink.class)
 @EnableConfigurationProperties(JdbcSinkProperties.class)

--- a/spring-cloud-starter-stream-sink-jdbc/src/main/java/org/springframework/cloud/stream/app/jdbc/sink/JdbcSinkConfiguration.java
+++ b/spring-cloud-starter-stream-sink-jdbc/src/main/java/org/springframework/cloud/stream/app/jdbc/sink/JdbcSinkConfiguration.java
@@ -160,7 +160,7 @@ public class JdbcSinkConfiguration {
 												return payload;
 											}
 										});
-						convertedMessage = new MutableMessage<>(messageStream.collect(Collectors.toList()));
+						convertedMessage = new MutableMessage<>(messageStream.collect(Collectors.toList()), message.getHeaders());
 					}
 					else {
 						if (convertibleContentType(contentType)) {

--- a/spring-cloud-starter-stream-sink-jdbc/src/test/java/org/springframework/cloud/stream/app/jdbc/sink/JdbcSinkIntegrationTests.java
+++ b/spring-cloud-starter-stream-sink-jdbc/src/test/java/org/springframework/cloud/stream/app/jdbc/sink/JdbcSinkIntegrationTests.java
@@ -50,6 +50,7 @@ import static org.hamcrest.Matchers.*;
  * @author Robert St. John
  * @author Oliver Flasch
  * @author Soby Chacko
+ * @author Szabolcs Stremler
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(
@@ -149,6 +150,20 @@ public abstract class JdbcSinkIntegrationTests {
 			Payload result = jdbcOperations
 					.query("select a, b from messages", new BeanPropertyRowMapper<>(Payload.class)).get(0);
 			Assert.assertThat(result, samePropertyValuesAs(expected));
+		}
+
+	}
+
+	@TestPropertySource(properties = "jdbc.columns=a: headers[foo]")
+	public static class HeaderInsertTests extends JdbcSinkIntegrationTests {
+
+		@Test
+		public void testHeaderInsertion() {
+			Payload sent = new Payload("hello", 42);
+			channels.input().send(MessageBuilder.withPayload(sent)
+					.setHeader("foo", "bar").build());
+			Assert.assertThat(jdbcOperations.queryForObject("select count(*) from messages where a = ?",
+					Integer.class, "bar"), is(1));
 		}
 
 	}


### PR DESCRIPTION
When I set `jdbc.columns=a: headers[foo]` the value of the `foo` header is not set as the value of the specified column and therefore cannot be inserted into the database, because in the `org.springframework.cloud.stream.app.jdbc.sink.JdbcSinkConfiguration.jdbcMessageHandler` method the original headers are not set to the converted message.

`convertedMessage = new MutableMessage<>(messageStream.collect(Collectors.toList()));` 

I considered it as a bug and I fixed the issue in this pull request and created a new test case as well.